### PR TITLE
Update StringBuffer.java

### DIFF
--- a/vm/JavaAPI/src/java/lang/StringBuffer.java
+++ b/vm/JavaAPI/src/java/lang/StringBuffer.java
@@ -357,7 +357,16 @@ public final class StringBuffer implements CharSequence, Appendable {
     }
 
     public CharSequence subSequence(int start, int end) {
-        return internal.substring(start, end);
+        if (this instanceof String) {
+            return ((String) this).substring(start, end);
+        } else {
+            int len = end - start;
+            char seq[] = new char[len];
+            for (int i = 0; i < len; i++) {
+                seq[i] = charAt(start + i);
+            }
+        return new String(seq);
+        }
     }
 
 


### PR DESCRIPTION
Preserving the generality of the subSequence() method, it can be used for all objects that implement the CharSequence interface, not just String and StringBuilder.